### PR TITLE
remove game-specific settings.  add warning that publishing and automation are not used.

### DIFF
--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -215,34 +215,6 @@ UI for configuring event settings.
                     value="{{.WarningRemainingDurationSec}}">
                 </div>
               </div>
-              <div class="row mb-3">
-                <label class="col-lg-6 control-label">Auto Bonus RP Coral Threshold</label>
-                <div class="col-lg-6">
-                  <input type="text" class="form-control" id="autoBonusCoralThreshold" name="autoBonusCoralThreshold"
-                    value="{{.AutoBonusCoralThreshold}}">
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label class="col-lg-6 control-label">Coopertition Bonus Enabled</label>
-                <div class="col-lg-1 checkbox">
-                  <input type="checkbox" id="coralBonusCoopEnabled"
-                    name="coralBonusCoopEnabled" {{if .CoralBonusCoopEnabled}} checked{{end}}>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <label class="col-lg-6 control-label">Coral Bonus RP Per-Level Threshold</label>
-                <div class="col-lg-6">
-                  <input type="text" class="form-control" id="coralBonusPerLevelThreshold"
-                    name="coralBonusPerLevelThreshold" value="{{.CoralBonusPerLevelThreshold}}">
-                </div>
-              </div>
-              <div class="row">
-                <label class="col-lg-6 control-label">Barge Bonus RP Point Threshold</label>
-                <div class="col-lg-6">
-                  <input type="text" class="form-control" id="bargeBonusPointThreshold" name="bargeBonusPointThreshold"
-                    value="{{.BargeBonusPointThreshold}}">
-                </div>
-              </div>
             </fieldset>
           </div>
           <div class="tab-pane" id="field" role="tabpanel">
@@ -383,6 +355,7 @@ UI for configuring event settings.
             </fieldset>
           </div>
           <div class="tab-pane" id="publishing" role="tabpanel">
+            <h4 class="text-danger">WARNING: Not Used</h4>
             <fieldset class="mb-4">
               <legend>Publishing</legend>
               <p>Contact The Blue Alliance to obtain an event code and credentials.</p>
@@ -416,6 +389,7 @@ UI for configuring event settings.
             
           </div>
           <div class="tab-pane" id="automation" role="tabpanel">
+            <h4 class="text-danger">WARNING: Not Used</h4>
             <fieldset class="mb-4">
               <legend>Nexus</legend>
               <p>Automatically populates practice and playoff match lineups from Nexus. Uses the same event code as TBA;


### PR DESCRIPTION
remove game-specific settings.  add warning that publishing and automation are not used.

avoiding removing publishing and automation sections altogether to set up for bringing that functionality back, gated by a setting.

https://github.com/Team766/cheesy-arena-generic/issues/7
https://github.com/Team766/cheesy-arena-generic/issues/8